### PR TITLE
sbi call 回傳值應儲存至 guest 的 A0 而非 A1

### DIFF
--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -10,6 +10,7 @@ mod vm;
 mod vm_pages;
 mod vmexit;
 mod vmm;
+mod vmm_trap;
 
 pub use ept::NestedPageTable;
 pub use regs::GprIndex;

--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -9,6 +9,7 @@ mod vcpu;
 mod vm;
 mod vm_pages;
 mod vmexit;
+mod vmm;
 
 pub use ept::NestedPageTable;
 pub use regs::GprIndex;
@@ -17,6 +18,7 @@ pub use smp::PerCpu;
 pub use vcpu::VCpu;
 pub use vm::VM;
 pub use vmexit::VmExitInfo;
+pub use vmm::VMM;
 
 use self::csrs::{traps, ReadWriteCsr, RiscvCsrTrait, CSR};
 use self::detect::detect_h_extension;

--- a/src/arch/riscv/vm.rs
+++ b/src/arch/riscv/vm.rs
@@ -65,7 +65,7 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VM<H, G> {
                             }
                             HyperCallMsg::GetChar => {
                                 let c = sbi_rt::legacy::console_getchar();
-                                gprs.set_reg(GprIndex::A1, c);
+                                gprs.set_reg(GprIndex::A0, c);
                             }
                             HyperCallMsg::PutChar(c) => {
                                 sbi_rt::legacy::console_putchar(c);

--- a/src/arch/riscv/vm.rs
+++ b/src/arch/riscv/vm.rs
@@ -47,6 +47,8 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VM<H, G> {
     pub fn run(&mut self, vcpu_id: usize) {
         let mut vm_exit_info: VmExitInfo;
         let mut gprs = GeneralPurposeRegisters::default();
+        // 設定時鐘中斷，定時脫出 loop
+        // 將 gprs 抽出到 vmm 層
         loop {
             let mut len = 4;
             let mut advance_pc = false;

--- a/src/arch/riscv/vmm.rs
+++ b/src/arch/riscv/vmm.rs
@@ -2,7 +2,10 @@ use alloc::vec::Vec;
 use riscv::register::time;
 
 use crate::{
-    arch::csrs::{traps, RiscvCsrTrait, CSR},
+    arch::{
+        csrs::{traps, RiscvCsrTrait, CSR},
+        vmm_trap::VmmTrap,
+    },
     GuestPageTableTrait, HyperCraftHal,
 };
 
@@ -10,6 +13,7 @@ use super::VM;
 /// virtual machine manager
 pub struct VMM<H: HyperCraftHal, G: GuestPageTableTrait> {
     vm_list: Vec<VM<H, G>>,
+    switch_vm_timer: u64,
 }
 
 fn get_time() -> u64 {
@@ -17,20 +21,25 @@ fn get_time() -> u64 {
 }
 
 // TODO: 確定 qemu 的時鐘頻率
-const TIME_SLICE: u64 = 10_0000;
-
-fn set_next_trigger() {
-    sbi_rt::set_timer(get_time() + TIME_SLICE);
-}
+const TIME_SLICE: u64 = 200_0000;
 
 impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
     /// 創建新的 VMM ，底下無任何虛擬機
     pub fn new() -> Self {
-        VMM { vm_list: vec![] }
+        VMM {
+            vm_list: vec![],
+            switch_vm_timer: u64::MAX,
+        }
     }
     /// 將虛擬機加入 VMM
     pub fn add_vm(&mut self, vm: VM<H, G>) {
         self.vm_list.push(vm);
+    }
+    fn set_switch_vm_timer(&mut self) {
+        self.switch_vm_timer = get_time() + TIME_SLICE;
+        CSR.sie
+            .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
+        sbi_rt::set_timer(self.switch_vm_timer);
     }
     /// 在 hart_id 上執行 VMM 管理的所有虛擬機
     pub fn run(&mut self, hart_id: usize) {
@@ -39,18 +48,51 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
 
         info!("vmm run cpu{}", hart_id);
 
-        // CSR.sie
-        //     .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
+        CSR.sie
+            .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
 
         let mut id = 0;
+        self.set_switch_vm_timer();
         loop {
-            debug!("執行虛擬機 {}", id);
+            // debug!("執行虛擬機 {}", id);
 
-            // set_next_trigger();
+            let vmm_trap = self.vm_list[id].run(0);
 
-            self.vm_list[id].run(0);
+            match vmm_trap {
+                VmmTrap::SetTimer(timer) => {
+                    CSR.sie
+                        .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
 
-            id = (id + 1) % vm_number;
+                    // let time = get_time();
+                    // debug!("虛擬機設定時鐘 {}", timer);
+                    // debug!("現在時鍾 {}", time);
+                    // TODO: 僅清除該 vm 的 hvip bit
+                    CSR.hvip
+                        .read_and_clear_bits(traps::interrupt::VIRTUAL_SUPERVISOR_TIMER);
+                    sbi_rt::set_timer(timer);
+                }
+                VmmTrap::TimerInterruptEmulation => {
+                    CSR.sie
+                        .read_and_clear_bits(traps::interrupt::SUPERVISOR_TIMER);
+
+                    let time = get_time();
+                    for vm in &mut self.vm_list {
+                        if time > vm.get_timer() {
+                            // TODO: 僅注入到該 vm
+                            // debug!("注入 hvip.stip");
+                            CSR.hvip
+                                .read_and_set_bits(traps::interrupt::VIRTUAL_SUPERVISOR_TIMER);
+                        }
+                    }
+                    // 現在時間已經超出時間片，切換虛擬機
+                    if time > self.switch_vm_timer {
+                        debug!("現在時間 {}，時間片到期時間 {}", time, self.switch_vm_timer);
+                        debug!("切換虛擬機");
+                        self.set_switch_vm_timer();
+                        id = (id + 1) % vm_number;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/arch/riscv/vmm.rs
+++ b/src/arch/riscv/vmm.rs
@@ -45,6 +45,7 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
     pub fn run(&mut self, hart_id: usize) {
         let vm_number = self.vm_list.len();
         assert_ne!(vm_number, 0);
+        debug!("虛擬機數量 {}", vm_number);
 
         info!("vmm run cpu{}", hart_id);
 
@@ -54,7 +55,7 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
         let mut id = 0;
         self.set_switch_vm_timer();
         loop {
-            // debug!("執行虛擬機 {}", id);
+            debug!("執行虛擬機 {}", id);
 
             let vmm_trap = self.vm_list[id].run(0);
 

--- a/src/arch/riscv/vmm.rs
+++ b/src/arch/riscv/vmm.rs
@@ -1,0 +1,56 @@
+use alloc::vec::Vec;
+use riscv::register::time;
+
+use crate::{
+    arch::csrs::{traps, RiscvCsrTrait, CSR},
+    GuestPageTableTrait, HyperCraftHal,
+};
+
+use super::VM;
+/// virtual machine manager
+pub struct VMM<H: HyperCraftHal, G: GuestPageTableTrait> {
+    vm_list: Vec<VM<H, G>>,
+}
+
+fn get_time() -> u64 {
+    time::read() as u64
+}
+
+// TODO: 確定 qemu 的時鐘頻率
+const TIME_SLICE: u64 = 10_0000;
+
+fn set_next_trigger() {
+    sbi_rt::set_timer(get_time() + TIME_SLICE);
+}
+
+impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
+    /// 創建新的 VMM ，底下無任何虛擬機
+    pub fn new() -> Self {
+        VMM { vm_list: vec![] }
+    }
+    /// 將虛擬機加入 VMM
+    pub fn add_vm(&mut self, vm: VM<H, G>) {
+        self.vm_list.push(vm);
+    }
+    /// 在 hart_id 上執行 VMM 管理的所有虛擬機
+    pub fn run(&mut self, hart_id: usize) {
+        let vm_number = self.vm_list.len();
+        assert_ne!(vm_number, 0);
+
+        info!("vmm run cpu{}", hart_id);
+
+        CSR.sie
+            .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
+
+        let mut id = 0;
+        loop {
+            debug!("執行虛擬機 {}", id);
+
+            set_next_trigger();
+
+            self.vm_list[id].run(0);
+
+            id = (id + 1) % vm_number;
+        }
+    }
+}

--- a/src/arch/riscv/vmm.rs
+++ b/src/arch/riscv/vmm.rs
@@ -39,14 +39,14 @@ impl<H: HyperCraftHal, G: GuestPageTableTrait> VMM<H, G> {
 
         info!("vmm run cpu{}", hart_id);
 
-        CSR.sie
-            .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
+        // CSR.sie
+        //     .read_and_set_bits(traps::interrupt::SUPERVISOR_TIMER);
 
         let mut id = 0;
         loop {
             debug!("執行虛擬機 {}", id);
 
-            set_next_trigger();
+            // set_next_trigger();
 
             self.vm_list[id].run(0);
 

--- a/src/arch/riscv/vmm_trap.rs
+++ b/src/arch/riscv/vmm_trap.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone, Copy)]
+/// Identifies the reason for a trap taken from a vCPU.
+pub enum VmmTrap {
+    /// 設定 timer
+    SetTimer(u64),
+    /// An timer interrupt for the running vCPU that can't be delegated and must be injected. The
+    /// interrupt is injected the vCPU is run.
+    TimerInterruptEmulation,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,14 @@
     unused_assignments
 )]
 #![deny(missing_docs, warnings)]
-
-#![feature(naked_functions, asm_const, negative_impls, stdsimd, inline_const, concat_idents)]
+#![feature(
+    naked_functions,
+    asm_const,
+    negative_impls,
+    stdsimd,
+    inline_const,
+    concat_idents
+)]
 
 #[macro_use]
 extern crate log;
@@ -39,16 +45,10 @@ mod vcpus;
 /// HyperCraft Result Define.
 pub type HyperResult<T = ()> = Result<T, HyperError>;
 
-
 #[cfg(not(target_arch = "aarch64"))]
-pub use arch::{
-    init_hv_runtime, GprIndex, HyperCallMsg, VmExitInfo,
-};
+pub use arch::{init_hv_runtime, GprIndex, HyperCallMsg, VmExitInfo};
 
-
-pub use arch::{
-    NestedPageTable, PerCpu, VCpu, VM,
-};
+pub use arch::{NestedPageTable, PerCpu, VCpu, VM};
 
 pub use hal::HyperCraftHal;
 pub use memory::{
@@ -57,11 +57,14 @@ pub use memory::{
 };
 pub use vcpus::VmCpus;
 
+#[cfg(target_arch = "riscv64")]
+pub use arch::VMM;
+
 #[cfg(target_arch = "aarch64")]
 pub use arch::lower_aarch64_synchronous;
 
 #[cfg(target_arch = "x86_64")]
-pub use arch::{VmxExitReason, VmxExitInfo};
+pub use arch::{VmxExitInfo, VmxExitReason};
 
 /// The error type for hypervisor operation failures.
 #[derive(Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     unused_imports,
-    unused_assignments
+    unused_assignments,
+    deprecated
 )]
 #![deny(missing_docs, warnings)]
 #![feature(


### PR DESCRIPTION
[SBI spec](https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-legacy.adoc) 提到
> The value returned in a0 register is SBI legacy extension specific

這份 patch 使依賴 RISCV sbi call 來 getchar 的系統能運行。